### PR TITLE
Branch permissions -- take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ stash.projects[PROJECT].repos.list()
 list(stash.projects[PROJECT].repos[REPO].pull_requests.commits())
 ```
 
+* List all branch restrictions for a repo
+```python
+stash.projects[PROJECT].repos[REPO].restricted.list()
+```
+
+* List all branch permission entities for a repo
+```python
+stash.projects[PROJECT].repos[REPO].permitted.list()
+```
+
 ## Implemented
 
 ```

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,10 @@
 stashy
 ======
 
-Python API client for the Atlassian Stash REST API
+Python client for the Atlassian Stash REST API. Supports Python 2.6, 2.7
+and 3.3.
+
+|Build Status|
 
 Installation
 ------------
@@ -13,7 +16,7 @@ Installation
 Usage
 -----
 
-::
+.. code:: python
 
     import stashy
     stash = stashy.connect("http://localhost:7990/stash", "admin", "admin")
@@ -23,39 +26,51 @@ Examples
 
 -  Retrieve all groups
 
-::
+.. code:: python
 
     stash.admin.groups.list()
 
 -  Retrieve all users that match a given filter
 
-::
+.. code:: python
 
     stash.admin.users.list(filter="admin")
 
 -  Add a user to a group
 
-::
+.. code:: python
 
     stash.admin.groups.add_user('stash-users', 'admin')
 
 -  Iterate over all projects (that you have access to)
 
-::
+.. code:: python
 
     stash.projects.list()
 
 -  List all the repositories in a given project
 
-::
+.. code:: python
 
     stash.projects[PROJECT].repos.list()
 
 -  List all the commits in a pull request
 
-::
+.. code:: python
 
     list(stash.projects[PROJECT].repos[REPO].pull_requests.commits())
+
+-  List all branch restrictions for a repo
+
+   .. code:: python
+
+       stash.projects[PROJECT].repos[REPO].restricted.list()
+
+-  List all branch permission entities for a repo
+
+   .. code:: python
+
+       stash.projects[PROJECT].repos[REPO].permitted.list()
 
 Implemented
 -----------
@@ -137,3 +152,5 @@ Not yet implemented
     /users [GET, PUT]
     /users/credentials [PUT]
 
+.. |Build Status| image:: https://travis-ci.org/RisingOak/stashy.png?branch=master
+   :target: https://travis-ci.org/RisingOak/stashy

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name='stashy',
-      version="0.1.1",
+      version="0.2",
       description='Python API client for the Atlassian Stash REST API',
       long_description=read('README.rst'),
       url='http://github.com/RisingOak/stashy',

--- a/stashy/branch_permissions.py
+++ b/stashy/branch_permissions.py
@@ -1,4 +1,4 @@
-from .helpers import ResourceBase, IterableResource
+from .helpers import ResourceBase, IterableResource, Nested
 from .errors import ok_or_error, response_or_error
 from .compat import update_doc
 
@@ -71,3 +71,8 @@ class Restricted(ResourceBase, IterableResource):
         return self._client.post(self.url(""), data=data)
 
 update_doc(Restricted.all, """Retrieve list of restrictions for a repo""")
+
+class BranchPermissions(ResourceBase):
+    """Simple parent resource for this api, to distinguish permissions from permitted"""
+    permitted = Nested(Permitted)
+    restricted = Nested(Restricted)

--- a/stashy/branch_permissions.py
+++ b/stashy/branch_permissions.py
@@ -1,0 +1,73 @@
+from .helpers import ResourceBase, IterableResource
+from .errors import ok_or_error, response_or_error
+from .compat import update_doc
+
+API_NAME = 'branch-permissions'
+API_VERSION = '1.0'
+API_OVERRIDE_PATH = '{0}/{1}'.format(API_NAME, API_VERSION)
+
+class Permitted(ResourceBase, IterableResource):
+    """Get-only resource that describes a permission record"""
+    def __init__(self, url, client, parent):
+        ResourceBase.__init__(self, url, client, parent, API_OVERRIDE_PATH)
+
+update_doc(Permitted.all, """Retrieve list of permitted entities for a repo""")
+
+
+class Restriction(ResourceBase):
+    def __init__(self, id, url, client, parent):
+        super(Restriction, self).__init__(url, client, parent, API_OVERRIDE_PATH)
+        self._id = id
+
+    @response_or_error
+    def get(self):
+        """
+        Retrieve a restriction
+        """
+        return self._client.get(self.url())
+
+    @ok_or_error
+    def delete(self):
+        """
+        Delete a restriction
+        """
+        return self._client.delete(self.url())
+
+    @response_or_error
+    def update(self, value, users=None, groups=None, pattern=False):
+        """
+        Re-restrict a branch, or set of branches defined by a pattern, to a set of users and/or groups
+        """
+        data = dict(type=('PATTERN' if pattern else 'BRANCH'), value=value)
+
+        if users is not None:
+            data['users'] = users
+        if groups is not None:
+            data['groups'] = groups
+
+        return self._client.put(self.url(""), data=data)
+
+
+class Restricted(ResourceBase, IterableResource):
+
+    def __init__(self, url, client, parent):
+        ResourceBase.__init__(self, url, client, parent, API_OVERRIDE_PATH)
+
+    def __getitem__(self, item):
+        return Restriction(item, self.url(item), self._client, self)
+
+    @response_or_error
+    def create(self, value, users=None, groups=None, pattern=False):
+        """
+        Restrict a branch, or set of branches defined by a pattern, to a set of users and/or groups
+        """
+        data = dict(type=('PATTERN' if pattern else 'BRANCH'), value=value)
+
+        if users is not None:
+            data['users'] = users
+        if groups is not None:
+            data['groups'] = groups
+
+        return self._client.post(self.url(""), data=data)
+
+update_doc(Restricted.all, """Retrieve list of restrictions for a repo""")

--- a/stashy/client.py
+++ b/stashy/client.py
@@ -30,7 +30,11 @@ class Stash(object):
 
 
 class StashClient(object):
-    api_version = '1.0'
+
+    # the core api path will be used as an overridable default
+    core_api_name = 'api'
+    core_api_version = '1.0'
+    core_api_path = '{0}/{1}'.format(core_api_name, core_api_version)
 
     def __init__(self, base_url, username=None, password=None, verify=True, session=None):
         assert isinstance(base_url, basestring)
@@ -40,7 +44,7 @@ class StashClient(object):
         else:
             self._base_url = base_url
 
-        self._api_base = self._base_url + "/rest/api/" + self.api_version
+        self._api_base = self._base_url + "/rest"
 
         if session is None:
             session = requests.Session()

--- a/stashy/helpers.py
+++ b/stashy/helpers.py
@@ -108,13 +108,21 @@ class FilteredIterableResource(IterableResource):
 
 
 class Nested(object):
-    def __init__(self, cls, relative_path=None):
-        if relative_path:
+    def __init__(self, cls, relative_path=''):
+
+        # nested object for clarity of usage, no effect on resource url
+        if relative_path is None:
+            self.relative_path = ''
+
+        # default case, use lowercase class name
+        elif not relative_path:
+            self.relative_path = "/%s" % cls.__name__.lower()
+
+        # explicit override of relative path
+        else:
             if not relative_path.startswith("/"):
                 relative_path = "/" + relative_path
             self.relative_path = relative_path
-        else:
-            self.relative_path = "/%s" % cls.__name__.lower()
         self.cls = cls
 
     def __get__(self, instance, kind):

--- a/stashy/helpers.py
+++ b/stashy/helpers.py
@@ -14,11 +14,22 @@ def add_json_headers(kw):
 
 
 class ResourceBase(object):
-    def __init__(self, url, client, parent):
-        self._url = url
+    def __init__(self, url, client, parent, api_path=None):
         self._client = client
         self._parent = parent
+        if api_path is None:
+            api_path = self._client.core_api_path
 
+        # make sure we're only prefixing with one api path
+        if url.startswith(api_path):
+            self._url = url
+        elif url.startswith(self._client.core_api_path):
+            self._url = url.replace(self._client.core_api_path, api_path)
+        else:
+            if url.startswith('/'):
+                url = url[1:]
+            self._url = '{0}/{1}'.format(api_path, url)
+ 
     def url(self, resource_url=""):
         if resource_url and not resource_url.startswith("/"):
             resource_url = "/" + resource_url

--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -3,7 +3,7 @@ from .errors import ok_or_error, response_or_error
 from .permissions import Permissions
 from .pullrequests import PullRequests
 from .compat import update_doc
-from .branch_permissions import Permitted, Restricted
+from .branch_permissions import BranchPermissions
 
 class Hook(ResourceBase):
     def __init__(self, key, url, client, parent):
@@ -201,10 +201,7 @@ class Repository(ResourceBase):
     permissions = Nested(Permissions)
     pull_requests = Nested(PullRequests, relative_path="/pull-requests")
     settings = Nested(Settings)
-
-    # branch-permissions items
-    permitted = Nested(Permitted)
-    restricted = Nested(Restricted)
+    branch_permissions = Nested(BranchPermissions, relative_path=None)
 
 
 class Repos(ResourceBase, IterableResource):

--- a/stashy/repos.py
+++ b/stashy/repos.py
@@ -3,6 +3,7 @@ from .errors import ok_or_error, response_or_error
 from .permissions import Permissions
 from .pullrequests import PullRequests
 from .compat import update_doc
+from .branch_permissions import Permitted, Restricted
 
 class Hook(ResourceBase):
     def __init__(self, key, url, client, parent):
@@ -200,6 +201,10 @@ class Repository(ResourceBase):
     permissions = Nested(Permissions)
     pull_requests = Nested(PullRequests, relative_path="/pull-requests")
     settings = Nested(Settings)
+
+    # branch-permissions items
+    permitted = Nested(Permitted)
+    restricted = Nested(Restricted)
 
 
 class Repos(ResourceBase, IterableResource):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,8 +5,8 @@ from stashy.client import StashClient
 class TestStashClient(TestCase):
     def test_url_without_slash_prefix(self):
         client = StashClient("http://example.com/stash")
-        self.assertEqual("http://example.com/stash/rest/api/1.0/admin/groups", client.url("admin/groups"))
+        self.assertEqual("http://example.com/stash/rest/api/1.0/admin/groups", client.url("api/1.0/admin/groups"))
 
     def test_url_with_slash_prefix(self):
         client = StashClient("http://example.com/stash")
-        self.assertEqual("http://example.com/stash/rest/api/1.0/admin/groups", client.url("/admin/groups"))
+        self.assertEqual("http://example.com/stash/rest/api/1.0/admin/groups", client.url("/api/1.0/admin/groups"))


### PR DESCRIPTION
This time I implemented the branch_permissions api urls as an override of the core api url in the utilizing modifications in StashClient and ResourceBase.  The solution is extensible, though I don't love the fact that `stash.projects[PROJECT].repos[REPO].permissions` and `stash.projects[PROJECT].repos[REPO].permitted` are so close and mean completely different things.