### PR TITLE
Update requests version to 2.5.1 for fix ssl issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 decorator==3.4.0
-requests==1.1.0
+requests==2.5.1


### PR DESCRIPTION
requests 1.1.0 could not handle ssl request. I manually run `pip uninstall requests` and `pip install requests`, then stashy worked fine.

Here is a log which I tried ssl request with requests 1.1.0.

``` shell-session
(CP341-test)[hiroyuki@mac01-2] $ python 
Python 3.4.1 (default, Oct 13 2014, 16:37:01) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.51)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests
>>> requests.get('https://github.com', verify=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hiroyuki.shirakawa/.pythonz/virtualenv/CP341-test/lib/python3.4/site-packages/requests/api.py", line 55, in get
    return request('get', url, **kwargs)
  File "/Users/hiroyuki.shirakawa/.pythonz/virtualenv/CP341-test/lib/python3.4/site-packages/requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/hiroyuki.shirakawa/.pythonz/virtualenv/CP341-test/lib/python3.4/site-packages/requests/sessions.py", line 279, in request
    resp = self.send(prep, stream=stream, timeout=timeout, verify=verify, cert=cert, proxies=proxies)
  File "/Users/hiroyuki.shirakawa/.pythonz/virtualenv/CP341-test/lib/python3.4/site-packages/requests/sessions.py", line 374, in send
    r = adapter.send(request, **kwargs)
  File "/Users/hiroyuki.shirakawa/.pythonz/virtualenv/CP341-test/lib/python3.4/site-packages/requests/adapters.py", line 174, in send
    timeout=timeout
  File "/Users/hiroyuki.shirakawa/.pythonz/virtualenv/CP341-test/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py", line 417, in urlopen
    conn = self._get_conn(timeout=pool_timeout)
  File "/Users/hiroyuki.shirakawa/.pythonz/virtualenv/CP341-test/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py", line 232, in _get_conn
    return conn or self._new_conn()
  File "/Users/hiroyuki.shirakawa/.pythonz/virtualenv/CP341-test/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py", line 547, in _new_conn
    strict=self.strict)
TypeError: __init__() got an unexpected keyword argument 'strict'
```
