### PR TITLE
Add Support For `/repos`

### DIFF
--- a/stashy/allrepos.py
+++ b/stashy/allrepos.py
@@ -1,0 +1,12 @@
+from .helpers import ResourceBase, IterableResource
+from .repos import Repository
+from .compat import update_doc
+
+class Repos(ResourceBase, IterableResource):
+  def __getitem__(self, item):
+    """
+    Return a :class:`Repository` object for operations on a specific repository
+    """
+    return Repository(item, self.url(item), self._client, self)
+
+update_doc(Repos.all, """Retreive repositories from Stash""")

--- a/stashy/client.py
+++ b/stashy/client.py
@@ -6,7 +6,7 @@ from .admin import Admin
 from .projects import Projects
 from .ssh import Keys
 from .compat import basestring
-
+from .allrepos import Repos
 
 class Stash(object):
     _url = "/"
@@ -17,6 +17,7 @@ class Stash(object):
     admin = Nested(Admin)
     projects = Nested(Projects)
     ssh = Nested(Keys)
+    repos = Nested(Repos)
 
     def groups(self, filter=None):
         """


### PR DESCRIPTION
Adds basic support for the `/repos` URI, listing all available Stash
repositories.