### PR TITLE
Allow later versions of the requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-decorator==3.4.0
-requests==1.1.0
+decorator>=3.4.0
+requests>=1.1.0


### PR DESCRIPTION
Pinning the versions creates huge interoperability issues with other packages.