### PR TITLE
Set content type in header to fix XSRF validation problem

### DIFF
--- a/stashy/client.py
+++ b/stashy/client.py
@@ -65,6 +65,7 @@ class StashClient(object):
             self._session.auth = (username, password)
 
         self._session.cookies = self._session.head(self.url("")).cookies
+        self._session.headers.update({'Content-Type': 'application/json'})
 
     def _create_oauth_session(self, oauth):
         from requests_oauthlib import OAuth1


### PR DESCRIPTION
Without content type, Bitbucket stop POSTs with
c.a.p.r.c.s.j.XsrfResourceFilter XSRF checks failed

Same problem can be seen when using curl without
-H "Content-Type: application/json"
