### PR TITLE
testing support for python 3.5, dropping 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.2
   - 3.3
+  - 3.5
 install: pip install -r requirements.txt
 script: python setup.py test


### PR DESCRIPTION
Just testing what Travis would look like for 3.5 support
Dropping support for 3.2
reference: https://groups.google.com/forum/#!msg/pypa-dev/Ef0PF2ZGAv0/hrO4BHkOBQAJ
official EOL https://www.python.org/dev/peps/pep-0392/#lifespan